### PR TITLE
Implemented onChange listener

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,15 @@ export class Ionic2MaskDirective {
     constructor(
         private control: NgControl
     ) { }
+    
+    /*when loading dynamically data to the input, without this 
+    the mask will only work on keyup event changes */
+    @HostListener('change') ngOnChanges() {
+        let value = this.control.control.value;
 
+        this.control.control.setValue(this.format(value));
+    }
+    
     @HostListener('keyup', ['$event'])
     onKeyUp($event: any) {
         if ($event.keyCode !== 13 && $event.keyCode !== 9) {


### PR DESCRIPTION
Implemented onChange listener, to apply mask when loading dinamically data at first time.

Without this, you can´t add mask to ion-input when you load dinamically data.